### PR TITLE
Call setup1 and loop1 for ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ ParamLOG_HeartbeatDelayTimeMS
 
 | ARCH   | info                                                                    |
 | ------ | ----------------------------------------------------------------------- |
-| RP204  | the reference platform with full support (including dual core support)  |
+| RP2040 | the reference platform with full support (including dual core support) |
 | SAMD21 | obsolete but still supported. no hw should be developed on this anymore |
-| ESP32  | experimental (single core only)                                         |
+| ESP32  | experimental                                                            |
 
 To configure the Hardware-Setup use the following defines in hardware.h
 

--- a/src/OpenKNX/defines.h
+++ b/src/OpenKNX/defines.h
@@ -85,3 +85,13 @@
     #define __time_critical_func(X) X
     #define __isr
 #endif
+
+#if defined(OPENKNX_DUALCORE) && defined(ARDUINO_ARCH_ESP32)
+    #ifndef ARDUINO_LOOP1_STACK_SIZE
+        #ifndef CONFIG_ARDUINO_LOOP1_STACK_SIZE
+            #define ARDUINO_LOOP1_STACK_SIZE 8192
+        #else
+            #define ARDUINO_LOOP1_STACK_SIZE CONFIG_ARDUINO_LOOP1_STACK_SIZE
+        #endif
+    #endif
+#endif


### PR DESCRIPTION
The arduino framework of ESP does not support the setup1 and loop1 function calls. The keep the code identical to RP2040 common should call these functions. 