### PR TITLE
add ChannelOwnerModule class

### DIFF
--- a/src/OpenKNX.h
+++ b/src/OpenKNX.h
@@ -43,3 +43,4 @@
 #include "OpenKNX/Hardware.h"
 #include "OpenKNX/Helper.h"
 #include "OpenKNX/Module.h"
+#include "OpenKNX/ChannelOwnerModule.h"

--- a/src/OpenKNX/ChannelOwnerModule.cpp
+++ b/src/OpenKNX/ChannelOwnerModule.cpp
@@ -1,0 +1,212 @@
+#include "OpenKNX/Facade.h"
+#include "OpenKNX/ChannelOwnerModule.h"
+
+namespace OpenKNX
+{
+    ChannelOwnerModule::ChannelOwnerModule(uint8_t numberOfChannels)
+        : _numberOfChannels(numberOfChannels)
+    {
+        if (_numberOfChannels > 0)
+        {
+            _pChannels = new OpenKNX::Channel*[numberOfChannels]();
+        }
+    }
+
+    ChannelOwnerModule::~ChannelOwnerModule()
+    {
+        if (_pChannels != nullptr)
+        {
+            delete[] _pChannels;
+            _pChannels = nullptr;
+        }
+    }
+
+    OpenKNX::Channel* ChannelOwnerModule::createChannel(uint8_t _channelIndex /* this parameter is used in macros, do not rename */)
+    {
+        return nullptr;
+    }
+
+    void ChannelOwnerModule::setup()
+    {
+        OpenKNX::Module::setup();
+        if (_pChannels != nullptr)
+        {
+            logDebugP("Setting up %d channels", _numberOfChannels);
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                logDebugP("Create channel %d", _channelIndex);
+                logIndentUp();
+                _pChannels[_channelIndex] = createChannel(_channelIndex);
+                logIndentDown();
+            }
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                {
+                    logDebugP("Init channel %d", _channelIndex);
+                    logIndentUp();
+                    channel->init();
+                    logIndentDown();
+
+                    logDebugP("Setup channel %d - setup(true)", _channelIndex);
+                    logIndentUp();
+                    channel->setup(true);
+                    logIndentDown();
+
+                    logInfoP("Setup channel %d - setup()", _channelIndex);
+                    logIndentUp();
+                    channel->setup();
+                    logIndentDown();
+                }
+            }
+        }
+    }
+
+    void ChannelOwnerModule::loop(bool configured)
+    {
+        OpenKNX::Module::loop(configured);
+        if (_pChannels != nullptr)
+        {
+            uint8_t processed = 0;
+            do
+            {
+                OpenKNX::Channel* channel = _pChannels[_currentChannel];
+                if (channel != nullptr)
+                {
+                    channel->loop(configured);
+                }
+            }
+            while (openknx.freeLoopIterate(_numberOfChannels, _currentChannel, processed));
+        }
+    }
+
+    OpenKNX::Channel* ChannelOwnerModule::getChannel(uint8_t channelIndex)
+    {
+        return _pChannels != nullptr ? _pChannels[channelIndex] : nullptr;
+    }
+
+    uint8_t ChannelOwnerModule::getNumberOfChannels()
+    {
+        return _numberOfChannels;
+    }
+
+    uint8_t ChannelOwnerModule::getNumberOfUsedChannels()
+    {
+        uint8_t activeChannels = 0;
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                    activeChannels++;
+            }
+        }
+        return activeChannels;
+    }
+
+    void ChannelOwnerModule::loop()
+    {
+        OpenKNX::Module::loop();
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                    channel->loop();
+            }
+        }
+    }
+
+#ifdef OPENKNX_DUALCORE
+    void ChannelOwnerModule::ChannelOwnerModule::setup1(bool configured)
+    {
+        OpenKNX::Module::setup1(configured);
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                {
+                    channel->setup1(configured);
+                }
+            }
+        }
+    }
+
+    void ChannelOwnerModule::ChannelOwnerModule::setup1()
+    {
+        OpenKNX::Module::setup1();
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                {
+                    channel->setup1();
+                }
+            }
+        }
+    }
+    /*
+     * Module logic for core1
+     */
+    void ChannelOwnerModule::loop1(bool configured)
+    {
+        OpenKNX::Module::loop1(configured);
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                {
+                    channel->loop1(configured);
+                }
+            }
+        }
+    }
+    void ChannelOwnerModule::loop1()
+    {
+        OpenKNX::Module::loop1();
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                {
+                    channel->loop1();
+                }
+            }
+        }
+    }
+#endif // OPENKNX_DUALCORE
+
+#if (MASK_VERSION & 0x0900) != 0x0900 // Coupler do not have GroupObjects
+    /*
+     * Called on incoming/changing GroupObject
+     * @param GroupObject
+     */
+    void ChannelOwnerModule::processInputKo(GroupObject& ko)
+    {
+        OpenKNX::Module::processInputKo(ko);
+        if (_pChannels != nullptr)
+        {
+            for (uint8_t _channelIndex = 0; _channelIndex < _numberOfChannels; _channelIndex++)
+            {
+                OpenKNX::Channel* channel = _pChannels[_channelIndex];
+                if (channel != nullptr)
+                {
+                    channel->processInputKo(ko);
+                }
+            }
+        }
+    }
+#endif // MASK_VERION
+
+} // namespace OpenKNX

--- a/src/OpenKNX/ChannelOwnerModule.h
+++ b/src/OpenKNX/ChannelOwnerModule.h
@@ -1,0 +1,98 @@
+#pragma once
+#include "OpenKNX/Module.h"
+#include "OpenKNX/Channel.h"
+
+namespace OpenKNX
+{
+    /*
+     * Base class for modules with channels
+     */
+    class ChannelOwnerModule : public OpenKNX::Module
+    {
+      private:
+        uint8_t _numberOfChannels;
+        uint8_t _currentChannel = 0;
+        OpenKNX::Channel** _pChannels = nullptr;
+
+      public:
+        /*
+         * Constructor. 
+         * Provide the number of the channels defined in the knxprod.h in the numberOfChannels parameter.
+         */
+        ChannelOwnerModule(uint8_t numberOfChannels = 0);
+        ~ChannelOwnerModule();
+
+        /* 
+         * Factory function for the channels.
+         * Override this function to create the channel objects.
+         * Returning nullptr is allowed to skip creation of a channel.
+         */
+        virtual OpenKNX::Channel* createChannel(uint8_t _channelIndex /* this parameter is used in macros, do not rename */);
+
+        /*
+         * This implementation calls the factory function createChannel for all channels
+         * If you override this function, don't forget to call this implementation to get the channels created.
+         */
+        virtual void setup() override;
+
+        /*
+         * This implementation calls the loop of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the loop function called in the channels.
+         */
+        virtual void loop(bool configured) override;
+        
+        /*
+         * This implementation calls the loop of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the loop function called in the channels.
+         */
+        virtual void loop() override;
+
+        /*
+         * Returns the number of created channels.
+         */
+        uint8_t getNumberOfUsedChannels();
+        /*
+         * Returns the number of all channels provided in the construtor.
+         */
+        uint8_t getNumberOfChannels();
+
+        /*
+         * Returns the channel object if created, otherwise a nullptr
+         */
+        OpenKNX::Channel* getChannel(uint8_t channelIndex);
+
+#ifdef OPENKNX_DUALCORE
+        /*
+         * This implementation calls the setup1 of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the setup1 function called in the channels.
+         */
+        virtual void setup1(bool configured) override;
+ 
+        /*
+         * This implementation calls the setup1 of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the setup1 function called in the channels.
+         */
+        virtual void setup1() override;
+
+        /*
+         * This implementation calls the loop of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the loop function called in the channels.
+         */
+        virtual void loop1(bool configured) override;
+
+        /*
+         * This implementation calls the loop of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the loop function called in the channels.
+         */
+        virtual void loop1() override;
+#endif
+
+#if (MASK_VERSION & 0x0900) != 0x0900 // Coupler do not have GroupObjects
+        /*
+         * This implementation calls the processInputKo of all channels. 
+         * If you override this function, don't forget to call this implemenation to get the processInputKo function called in the channels.
+         */
+        virtual void processInputKo(GroupObject& ko) override;
+#endif
+    };
+} // namespace OpenKNX


### PR DESCRIPTION
I use a local copy of this class already in several modules. The idea behind this class is, to centralize the handling of channels in one common place. 

Another possibilities for this implementation would be to merge it directly to OpenKNX::Module. The behavior would be fully downwards compatible. Only if the constructor with the number of channels will be used, the new functions will be used.

I would also add the same channel handling for the console functions, but for this, the console functions processCommand and showHelp must be moved from OpenKNX::Module to OpenKNC::Base.