### PR TITLE
Addition to Previous Merged Pull Request for Flash Double Read/Write Methods

### DIFF
--- a/src/OpenKNX/Flash/Default.cpp
+++ b/src/OpenKNX/Flash/Default.cpp
@@ -427,6 +427,16 @@ namespace OpenKNX
             write((uint8_t *)&value, 4);
         }
 
+        void Default::writeLong(long value)
+        {
+            write((uint8_t *)&value, 8);
+        }
+
+        void Default::writeDouble(double value)
+        {
+            write((uint8_t *)&value, 8);
+        }
+
         void Default::writeFilldata()
         {
             uint16_t fillSize = (_maxWriteAddress - _currentWriteAddress);
@@ -465,6 +475,18 @@ namespace OpenKNX
         {
             _currentReadAddress += 4;
             return openknx.openknxFlash.readFloat(_currentReadAddress - 4);
+        }
+
+        long Default::readLong()
+        {
+            _currentReadAddress += 8;
+            return openknx.openknxFlash.readFloat(_currentReadAddress - 8);
+        }
+
+        double Default::readDouble()
+        {
+            _currentReadAddress += 8;
+            return openknx.openknxFlash.readFloat(_currentReadAddress - 8);
         }
 
         uint16_t Default::firmwareVersion()

--- a/src/OpenKNX/Flash/Default.h
+++ b/src/OpenKNX/Flash/Default.h
@@ -194,11 +194,15 @@ namespace OpenKNX
             void writeWord(uint16_t value);
             void writeInt(uint32_t value);
             void writeFloat(float value);
+            void writeLong(long value);
+            void writeDouble(double value);
             uint8_t *read(uint16_t size = 1);
             uint8_t readByte();
             uint16_t readWord();
             uint32_t readInt();
             float readFloat();
+            long readLong();
+            double readDouble();
             uint16_t firmwareVersion();
             uint32_t lastWrite();
 

--- a/src/OpenKNX/Flash/Driver.cpp
+++ b/src/OpenKNX/Flash/Driver.cpp
@@ -283,7 +283,12 @@ namespace OpenKNX
             return write(relativeAddress, (uint8_t *)&value, 4);
         }
 
-        uint64_t Driver::writeDouble(uint32_t relativeAddress, double value)
+        uint32_t Driver::writeLong(uint32_t relativeAddress, long value)
+        {
+            return write(relativeAddress, (uint8_t *)&value, 8);
+        }
+
+        uint32_t Driver::writeDouble(uint32_t relativeAddress, double value)
         {
             return write(relativeAddress, (uint8_t *)&value, 8);
         }
@@ -319,6 +324,13 @@ namespace OpenKNX
         {
             float buffer = 0;
             read(relativeAddress, (uint8_t *)&buffer, 4);
+            return buffer;
+        }
+
+        long Driver::readLong(uint32_t relativeAddress)
+        {
+            long buffer = 0;
+            read(relativeAddress, (uint8_t *)&buffer, 8);
             return buffer;
         }
 

--- a/src/OpenKNX/Flash/Driver.h
+++ b/src/OpenKNX/Flash/Driver.h
@@ -60,7 +60,8 @@ namespace OpenKNX
             uint32_t writeWord(uint32_t relativeAddress, uint16_t value);
             uint32_t writeInt(uint32_t relativeAddress, uint32_t value);
             uint32_t writeFloat(uint32_t relativeAddress, float value);
-            uint64_t writeDouble(uint32_t relativeAddress, double value);
+            uint32_t writeLong(uint32_t relativeAddress, long value);
+            uint32_t writeDouble(uint32_t relativeAddress, double value);
 
             uint32_t read(uint32_t relativeAddress, uint8_t *output, uint32_t size);
 
@@ -68,6 +69,7 @@ namespace OpenKNX
             uint16_t readWord(uint32_t relativeAddress);
             uint32_t readInt(uint32_t relativeAddress);
             float readFloat(uint32_t relativeAddress);
+            long readLong(uint32_t relativeAddress);
             double readDouble(uint32_t relativeAddress);
         };
     } // namespace Flash


### PR DESCRIPTION
- Added missing default overloads for flash double read/write methods.
- Added long read/write methods as well for consistency.

As `v1dev` got merged to `v1` now, I'm creating this pull request directly towards `v1`.
In case still preferred against `v1dev`, let me know.