### PR TITLE
Fix New Types in Flash Read/Write

### DIFF
--- a/src/OpenKNX/Flash/Default.cpp
+++ b/src/OpenKNX/Flash/Default.cpp
@@ -480,13 +480,13 @@ namespace OpenKNX
         long Default::readLong()
         {
             _currentReadAddress += 8;
-            return openknx.openknxFlash.readFloat(_currentReadAddress - 8);
+            return openknx.openknxFlash.readLong(_currentReadAddress - 8);
         }
 
         double Default::readDouble()
         {
             _currentReadAddress += 8;
-            return openknx.openknxFlash.readFloat(_currentReadAddress - 8);
+            return openknx.openknxFlash.readDouble(_currentReadAddress - 8);
         }
 
         uint16_t Default::firmwareVersion()

--- a/src/OpenKNX/Flash/Default.cpp
+++ b/src/OpenKNX/Flash/Default.cpp
@@ -427,7 +427,7 @@ namespace OpenKNX
             write((uint8_t *)&value, 4);
         }
 
-        void Default::writeLong(long value)
+        void Default::writeLong(uint64_t value)
         {
             write((uint8_t *)&value, 8);
         }
@@ -477,7 +477,7 @@ namespace OpenKNX
             return openknx.openknxFlash.readFloat(_currentReadAddress - 4);
         }
 
-        long Default::readLong()
+        uint64_t Default::readLong()
         {
             _currentReadAddress += 8;
             return openknx.openknxFlash.readLong(_currentReadAddress - 8);

--- a/src/OpenKNX/Flash/Default.h
+++ b/src/OpenKNX/Flash/Default.h
@@ -194,14 +194,14 @@ namespace OpenKNX
             void writeWord(uint16_t value);
             void writeInt(uint32_t value);
             void writeFloat(float value);
-            void writeLong(long value);
+            void writeLong(uint64_t value);
             void writeDouble(double value);
             uint8_t *read(uint16_t size = 1);
             uint8_t readByte();
             uint16_t readWord();
             uint32_t readInt();
             float readFloat();
-            long readLong();
+            uint64_t readLong();
             double readDouble();
             uint16_t firmwareVersion();
             uint32_t lastWrite();

--- a/src/OpenKNX/Flash/Driver.cpp
+++ b/src/OpenKNX/Flash/Driver.cpp
@@ -283,7 +283,7 @@ namespace OpenKNX
             return write(relativeAddress, (uint8_t *)&value, 4);
         }
 
-        uint32_t Driver::writeLong(uint32_t relativeAddress, long value)
+        uint32_t Driver::writeLong(uint32_t relativeAddress, uint64_t value)
         {
             return write(relativeAddress, (uint8_t *)&value, 8);
         }

--- a/src/OpenKNX/Flash/Driver.h
+++ b/src/OpenKNX/Flash/Driver.h
@@ -60,7 +60,7 @@ namespace OpenKNX
             uint32_t writeWord(uint32_t relativeAddress, uint16_t value);
             uint32_t writeInt(uint32_t relativeAddress, uint32_t value);
             uint32_t writeFloat(uint32_t relativeAddress, float value);
-            uint32_t writeLong(uint32_t relativeAddress, long value);
+            uint32_t writeLong(uint32_t relativeAddress, uint64_t value);
             uint32_t writeDouble(uint32_t relativeAddress, double value);
 
             uint32_t read(uint32_t relativeAddress, uint8_t *output, uint32_t size);


### PR DESCRIPTION
* Default::readLong/Double called readFloat - wrong results expected
* Value-Type of read/writeLong was not defined consistently as uint64_t