### PR TITLE
fix delayTimerInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Update: Scripts
 * App: Support SerialLED (Neopixel/WS2812)
 * Add: PSRAM info in 'm' console command
+* Fix: delayTimerInit could return 0 in case of overflow between calls to millis()
 
 ## 1.2.0: 2024-07-02
 * Update: RP2040 Platform to Core 3.9.3

--- a/src/OpenKNX/Helper.h
+++ b/src/OpenKNX/Helper.h
@@ -9,7 +9,7 @@
 #define delayCheckMillis(last, duration) (millis() - last >= duration)
 #define delayCheckMicros(last, duration) (micros() - last >= duration)
 #define delayCheck(last, duration) delayCheckMillis(last, duration)
-#define delayTimerInit() (millis() == 0 ? 1 : millis())
+#define delayTimerInit() (max(millis(), 1UL))
 
 #define NO_NUM -987654321.0F // normal NAN-Handling does not work
 #define isNum(value) ((value + 10.0) > NO_NUM)


### PR DESCRIPTION
In case of an overflow between the two calls to millis, the macro could return 0.