### PR TITLE
Workaround for KO numbers of base in knxprod created with creator

### DIFF
--- a/src/OpenKNX/Common.cpp
+++ b/src/OpenKNX/Common.cpp
@@ -743,13 +743,17 @@ namespace OpenKNX
 #if (MASK_VERSION & 0x0900) != 0x0900 // Coupler do not have GroupObjects
     void Common::processInputKo(GroupObject& ko)
     {
+    #ifndef BASE_KoManualSave
+        #define BASE_KoManualSave 0
+    #endif
+
     #ifdef BASE_KoDiagnose
-        if (ko.asap() == BASE_KoDiagnose)
+        if (ko.asap() == (BASE_KoDiagnose + BASE_KoManualSave))
             return openknx.console.processDiagnoseKo(ko);
     #endif
 
     #ifdef BASE_KoManualSave
-        if (ko.asap() == BASE_KoManualSave)
+        if (ko.asap() == (BASE_KoManualSave + BASE_KoManualSave))
             return processSaveKo(ko);
     #endif
         openknx.time.processInputKo(ko);

--- a/src/OpenKNX/Common.cpp
+++ b/src/OpenKNX/Common.cpp
@@ -743,17 +743,17 @@ namespace OpenKNX
 #if (MASK_VERSION & 0x0900) != 0x0900 // Coupler do not have GroupObjects
     void Common::processInputKo(GroupObject& ko)
     {
-    #ifndef BASE_KoManualSave
-        #define BASE_KoManualSave 0
+    #ifndef BASE_Share_KoOffset
+        #define BASE_Share_KoOffset 0
     #endif
 
     #ifdef BASE_KoDiagnose
-        if (ko.asap() == (BASE_KoDiagnose + BASE_KoManualSave))
+        if (ko.asap() == (BASE_KoDiagnose + BASE_Share_KoOffset))
             return openknx.console.processDiagnoseKo(ko);
     #endif
 
     #ifdef BASE_KoManualSave
-        if (ko.asap() == (BASE_KoManualSave + BASE_KoManualSave))
+        if (ko.asap() == (BASE_KoManualSave + BASE_Share_KoOffset))
             return processSaveKo(ko);
     #endif
         openknx.time.processInputKo(ko);

--- a/src/OpenKNX/Time/TimeManager.cpp
+++ b/src/OpenKNX/Time/TimeManager.cpp
@@ -629,6 +629,10 @@ namespace OpenKNX
 
         void TimeManager::processInputKo(GroupObject& ko)
         {
+            #ifndef BASE_Share_KoOffset
+                #define BASE_Share_KoOffset 0
+            #endif
+
             if (_timeProvider != nullptr)
             {
                 _timeProvider->processInputKo(ko);
@@ -637,7 +641,7 @@ namespace OpenKNX
             // <Enumeration Text="Kommunikationsobjekt 'Sommerzeit aktiv'" Value="0" Id="%ENID%" />
             // <Enumeration Text="Kombiniertes Datum/Zeit-KO (DPT 19)" Value="1" Id="%ENID%" />
             // <Enumeration Text="Interne Berechnung (nur in Deutschland)" Value="2" Id="%ENID%" />
-            if (!_timeProvideSupportKnxDaylightSavingTimeSwitch && ko.asap() == BASE_KoIsSummertime && ParamBASE_SummertimeAll == 0)
+            if (!_timeProvideSupportKnxDaylightSavingTimeSwitch && ko.asap() == (BASE_KoIsSummertime + BASE_Share_KoOffset) && ParamBASE_SummertimeAll == 0)
             {
                 _waitTimerReadKo = 0;
                 bool dst = (bool)ko.value(DPT_Switch);


### PR DESCRIPTION
This PR will fix the handling with the ko numbers when created with kaenx-creator.
