### PR TITLE
call a DEVICE_INIT() Macro, if present.

### DIFF
--- a/src/OpenKNX/Common.cpp
+++ b/src/OpenKNX/Common.cpp
@@ -26,6 +26,9 @@ namespace OpenKNX
 
     void Common::init(uint8_t firmwareRevision)
     {
+        #ifdef DEVICE_INIT
+            DEVICE_INIT();
+        #endif
         ArduinoPlatform::SerialDebug = new OpenKNX::Log::VirtualSerial("KNX");
 
         openknx.timerInterrupt.init();


### PR DESCRIPTION
Meant to be defined in HardwareConfig for e.g. setting up GPIOs etc..