### PR TITLE
Use custom defined  button pin and interrupt modes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,3 +36,4 @@ ContinuationIndentWidth: 4
 UseTab: Never
 IndentPPDirectives: BeforeHash
 ...
+#EOF

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ KNX_UART_TX_PIN
 | INFO3_LED_PIN_ACTIVE_ON         |   undef |       | values: LOW or HIGH, indicates at which GPIO state the LED is active (no function with SERIALLED)                                    |
 | INFO3_LED_COLOR                 |  0,63,0 |       | set the color for the LED, default: 50% green - only for SERIALLED                                                                   |
 
+### Buttons
+| define                          |      default | unit  | function                                                                                                                        |
+| PROG_BUTTON_PIN                 |        undef |  GPIO | to drive the OPenKNX programming button. Button supports short press (<1000ms), long press, and double press (500ms intervals). |
+| PROG_BUTTON_PIN_MODE            | INPUT_PULLUP |       | values: INPUT_PULLUP, INPUT_PULLDOWN, INPUT. Specifies the mode for the programming button pin.                                 |
+| OPENKNX_BUTTON_DEBOUNCE         |      50      |  ms   | Software debounce time for buttons to avoid false triggers. Setting to 0 disables it (i.e. to use Hardware debounce).           |
 
 ### Heartbeat (Mode: Normal)
 You can enable a debug heartbeat to see if a loop is stuck. The progLed (for loop) and infoLed (for loop1) will blinking if the loop hangs.

--- a/src/OpenKNX/Button.cpp
+++ b/src/OpenKNX/Button.cpp
@@ -24,7 +24,11 @@ namespace OpenKNX
                 if (_doubleClickCallback == nullptr)
                 {
                     // No wait for double click for faster response
-                    if (!_processed && _holdTimer && delayCheck(_holdTimer, OPENKNX_BUTTON_DEBOUNCE))
+                    if (!_processed
+#if OPENKNX_BUTTON_DEBOUNCE > 0
+                        && delayCheck(_holdTimer, OPENKNX_BUTTON_DEBOUNCE)
+#endif
+                    )
                     {
                         callShortClickCallback();
                     }

--- a/src/OpenKNX/Button.h
+++ b/src/OpenKNX/Button.h
@@ -4,7 +4,9 @@
 #include <functional>
 #include <string>
 
-#define OPENKNX_BUTTON_DEBOUNCE 50
+#ifndef OPENKNX_BUTTON_DEBOUNCE
+    #define OPENKNX_BUTTON_DEBOUNCE 50
+#endif
 #define OPENKNX_BUTTON_DOUBLE_CLICK 500
 #define OPENKNX_BUTTON_LONG_CLICK 1000
 
@@ -38,7 +40,7 @@ namespace OpenKNX
         inline void callDoubleClickCallback();
 
       public:
-        Button(const char *id) : _id(id){};
+        Button(const char *id) : _id(id) {};
         void change(bool pressed);
         void loop();
 

--- a/src/OpenKNX/Common.cpp
+++ b/src/OpenKNX/Common.cpp
@@ -106,7 +106,10 @@ namespace OpenKNX
     void Common::processRecovery()
     {
         bool erase = false;
-        pinMode(PROG_BUTTON_PIN, INPUT_PULLUP);
+        #ifndef PROG_BUTTON_PIN_MODE
+            #define PROG_BUTTON_PIN_MODE INPUT_PULLUP
+        #endif
+        pinMode(PROG_BUTTON_PIN, PROG_BUTTON_PIN_MODE);
         while (!digitalRead(PROG_BUTTON_PIN))
         {
             if (millis() >= OPENKNX_RECOVERY_TIME)

--- a/src/OpenKNX/Hardware.cpp
+++ b/src/OpenKNX/Hardware.cpp
@@ -94,33 +94,41 @@ namespace OpenKNX
 
     void Hardware::initButtons()
     {
+#define ATTACH_BUTTON_INTERRUPT(PIN, MODE)                                              \
+    pinMode(PIN, MODE);                                                                                 \
+    attachInterrupt(                                                                                    \
+        digitalPinToInterrupt(PIN),                                                                     \
+        []() -> void {                                                                                  \
+            openknx.progButton.change((MODE == INPUT_PULLUP) ? !digitalRead(PIN) : digitalRead(PIN));   \
+        }, CHANGE); // Interrupt on change only, since we will detect short, long and double or n clicks
+
 #ifdef PROG_BUTTON_PIN
-        pinMode(PROG_BUTTON_PIN, INPUT_PULLUP);
-        attachInterrupt(
-            digitalPinToInterrupt(PROG_BUTTON_PIN),
-            []() -> void { openknx.progButton.change(!digitalRead(PROG_BUTTON_PIN)); }, CHANGE);
-#endif
+    #ifndef PROG_BUTTON_PIN_MODE
+        #define PROG_BUTTON_PIN_MODE INPUT_PULLUP
+    #endif
+        ATTACH_BUTTON_INTERRUPT(PROG_BUTTON_PIN, PROG_BUTTON_PIN_MODE);
+#endif // PROG_BUTTON_PIN
 
 #ifdef FUNC1_BUTTON_PIN
-        pinMode(FUNC1_BUTTON_PIN, INPUT_PULLUP);
-        attachInterrupt(
-            digitalPinToInterrupt(FUNC1_BUTTON_PIN),
-            []() -> void { openknx.func1Button.change(!digitalRead(FUNC1_BUTTON_PIN)); }, CHANGE);
-#endif
+    #ifndef FUNC1_BUTTON_MODE
+        #define FUNC1_BUTTON_MODE INPUT_PULLUP
+    #endif
+        ATTACH_BUTTON_INTERRUPT(FUNC1_BUTTON_PIN, FUNC1_BUTTON_MODE);
+#endif // FUNC1_BUTTON_PIN
 
 #ifdef FUNC2_BUTTON_PIN
-        pinMode(FUNC2_BUTTON_PIN, INPUT_PULLUP);
-        attachInterrupt(
-            digitalPinToInterrupt(FUNC2_BUTTON_PIN),
-            []() -> void { openknx.func2Button.change(!digitalRead(FUNC2_BUTTON_PIN)); }, CHANGE);
-#endif
+    #ifndef FUNC2_BUTTON_MODE
+        #define FUNC2_BUTTON_MODE INPUT_PULLUP
+    #endif
+        ATTACH_BUTTON_INTERRUPT(FUNC2_BUTTON_PIN, FUNC2_BUTTON_MODE);
+#endif // FUNC2_BUTTON_PIN
 
 #ifdef FUNC3_BUTTON_PIN
-        pinMode(FUNC3_BUTTON_PIN, INPUT_PULLUP);
-        attachInterrupt(
-            digitalPinToInterrupt(FUNC3_BUTTON_PIN),
-            []() -> void { openknx.func3Button.change(!digitalRead(FUNC3_BUTTON_PIN)); }, CHANGE);
-#endif
+    #ifndef FUNC3_BUTTON_MODE
+        #define FUNC3_BUTTON_MODE INPUT_PULLUP
+    #endif
+        ATTACH_BUTTON_INTERRUPT(FUNC3_BUTTON_PIN, FUNC3_BUTTON_MODE);
+#endif // FUNC3_BUTTON_PIN
     }
 
     void Hardware::initKnxRxISR()


### PR DESCRIPTION
- Add support for custom button pin modes and interrupt modes for Prog, Func1-3 buttons:
- Common::processRecovery() now uses PROG_BUTTON_PIN_MODE if defined, else falls back to default behavior.
- Button software debounce is now configurable. (Check Readme!)

Others:
- Added #EOF to .clang-format again, as clang on macOS cannot handle it otherwise.
