### PR TITLE
Add support for 4MB flash

### DIFF
--- a/platformio.rp2040.ini
+++ b/platformio.rp2040.ini
@@ -43,13 +43,18 @@ build_flags =
 
 ; 16MB Flash
 [RP2040_16MB]
-board_upload.maximum_size = 16777216
-board_build.filesystem_size = 15724544
+board_upload.maximum_size = 16777216 ; 16MB
+board_build.filesystem_size = 15724544 ; 15.5MB
+
+; 4MB Flash
+[RP2040_4MB]
+board_upload.maximum_size = 4194304 ; 4MB 
+board_build.filesystem_size = 1572864 ; 1.5MB
 
 ; 2MB Flash
 [RP2040_2MB]
-board_upload.maximum_size = 2097152
-board_build.filesystem_size = 1044480
+board_upload.maximum_size = 2097152 ; 2MB
+board_build.filesystem_size = 1044480 ; 1MB
 
 ; obsolete
 [RP2040_UPLOAD_USB]


### PR DESCRIPTION
To support the Pi Pico2 (rp2350), which has default on-board flash of 4MB