### PR TITLE
Add support for 4MB flash

### DIFF
--- a/platformio.rp2040.ini
+++ b/platformio.rp2040.ini
@@ -41,15 +41,28 @@ build_flags =
   -D OPENKNX_WATCHDOG
   ${RP2040.build_flags}
 
+
+; ================================= FLASH SIZES =================================
+; The initial 1,048,576 bytes (1MiB) have been preserved to maintain a consistent 
+; flash partitioning and ensure compatibility. This is the minimum size!
+; 
+; On total flash size >1MB, only the file sytem profits from the additional space.
+; Keep in mind that we need at the fs end at least 4096 bytes for EEPROM emulation.
+
 ; 16MB Flash
 [RP2040_16MB]
-board_upload.maximum_size = 16777216
-board_build.filesystem_size = 15724544
+board_upload.maximum_size = 16777216 ; 16MiB (Total size of the flash)
+board_build.filesystem_size = 15724544 ; 15MiB (16MiB - 1MiB - 4096 bytes)
+
+; 4MB Flash
+[RP2040_4MB]
+board_upload.maximum_size = 4194304 ; 4MiB (Total size of the flash)
+board_build.filesystem_size = 3141632 ; 3MiB (4MiB - 1MiB - 4096 bytes)
 
 ; 2MB Flash
 [RP2040_2MB]
-board_upload.maximum_size = 2097152
-board_build.filesystem_size = 1044480
+board_upload.maximum_size = 2097152 ; 2MiB (Total size of the flash)
+board_build.filesystem_size = 1044480 ; 1MiB (2MiB - 1MiB - 4096 bytes)
 
 ; obsolete
 [RP2040_UPLOAD_USB]


### PR DESCRIPTION
to support the Pi Pico2 (rp2350), which has default on-board flash of 4MB