### PR TITLE
Exclude 7FFFh from DPT9 ParamType as Used for "Invalid Data" and Ignored by Stack

### DIFF
--- a/src/Common.share.xml
+++ b/src/Common.share.xml
@@ -110,7 +110,9 @@
                 <TypeNumber SizeInBit="16" Type="signedInt" minInclusive="-32768" maxInclusive="32767" />
               </ParameterType>
               <ParameterType Id="%AID%_PT-ValueDpt9" Name="ValueDpt9">
-                <TypeFloat Encoding="IEEE-754 Single" minInclusive="-671088" maxInclusive="670760" />
+                <!-- ETS 5.7 allows range of -670760..670760 -->
+                <!-- max Value is below, as 7FFFh is reserved for "invalid data" in DPT 9-->
+                <TypeFloat Encoding="IEEE-754 Single" minInclusive="-671088" maxInclusive="670433" />
               </ParameterType>
               <ParameterType Id="%AID%_PT-ValueDpt12" Name="ValueDpt12">
                 <TypeNumber SizeInBit="32" Type="unsignedInt" minInclusive="0" maxInclusive="4294967295" />


### PR DESCRIPTION
Der Stack schreibt für DPT9 keine Werte >670433, da der nächstgrößere Wert 670760~=0x7FFF reserviert ist zur Codierung von ungültigen Werten.

Die Änderung von ParameterType `%AID%_PT-ValueDpt9` hat Einfluss auf bestehende Module, die Parameter dieses Typs einsetzen. Siehe https://github.com/search?q=org%3AOpenKNX%20PT-ValueDpt9&type=code (durchsucht nur Default-Branch). Mindestens folgende:
* [OFM-THPSensorModule](https://github.com/OpenKNX/OFM-THPSensorModule)
* [OFM-LogicModule](https://github.com/OpenKNX/OFM-LogicModule)
* [OAM-WeatherWN90LP](https://github.com/OpenKNX/OAM-WeatherWN90LP)
* [OFM-DFA](https://github.com/OpenKNX/OFM-DFA)
* [OFM-FunctionBlocks](https://github.com/OpenKNX/OFM-FunctionBlocks)

Ggf. ist es daher besser, wenn wir diesen Typ ersetzten durch einen anders benannten