### PR TITLE
Change Module Help Behaviour: Show when Configured Only as Default

### DIFF
--- a/src/OpenKNX/Console.cpp
+++ b/src/OpenKNX/Console.cpp
@@ -596,7 +596,7 @@ namespace OpenKNX
 #endif
 
         for (uint8_t i = 0; i < openknx.modules.count; i++)
-            openknx.modules.list[i]->showHelp();
+            openknx.modules.list[i]->showHelp(knx.configured());
 
         openknx.logger.logDividingLine();
         logEnd();

--- a/src/OpenKNX/Console.cpp
+++ b/src/OpenKNX/Console.cpp
@@ -306,8 +306,9 @@ namespace OpenKNX
         else
         {
             // check modules for command
+            bool configured = knx.configured();
             for (uint8_t i = 0; i < openknx.modules.count; i++)
-                if (openknx.modules.list[i]->processCommand(cmd, diagnoseKo))
+                if (openknx.modules.list[i]->processCommand(configured, cmd, diagnoseKo))
                     return true;
             return false;
         }

--- a/src/OpenKNX/Console.cpp
+++ b/src/OpenKNX/Console.cpp
@@ -595,8 +595,9 @@ namespace OpenKNX
         printHelpLine("sun", "Shows sun information");
 #endif
 
+        bool configured = knx.configured();
         for (uint8_t i = 0; i < openknx.modules.count; i++)
-            openknx.modules.list[i]->showHelp(knx.configured());
+            openknx.modules.list[i]->showHelp(configured);
 
         openknx.logger.logDividingLine();
         logEnd();

--- a/src/OpenKNX/Module.cpp
+++ b/src/OpenKNX/Module.cpp
@@ -46,6 +46,11 @@ namespace OpenKNX
         return false;
     }
 
+    void Module::showHelp(bool configured)
+    {
+        if (configured) showHelp();
+    }
+
     void Module::showHelp()
     {
         // Example usage:

--- a/src/OpenKNX/Module.cpp
+++ b/src/OpenKNX/Module.cpp
@@ -41,6 +41,14 @@ namespace OpenKNX
         // logInfoP("Some-Integer: %i", myInteger);
     }
 
+    bool Module::processCommand(bool configured, const std::string cmd, bool diagnoseKo)
+    {
+        if (configured)
+            return processCommand(cmd, diagnoseKo);
+        else
+            return false;
+    }
+
     bool Module::processCommand(const std::string cmd, bool diagnoseKo)
     {
         return false;

--- a/src/OpenKNX/Module.h
+++ b/src/OpenKNX/Module.h
@@ -104,6 +104,7 @@ namespace OpenKNX
         /**
          * This method prints out information over the command it can handle
          */
+        virtual void showHelp(bool configured);
         virtual void showHelp();
 
         /**

--- a/src/OpenKNX/Module.h
+++ b/src/OpenKNX/Module.h
@@ -92,12 +92,28 @@ namespace OpenKNX
 
         /**
          * This method is called when a command is entered in the console or the diagnoseKo.
-         * The first argument is the command, and the second argument indicates whether the call was made via diagnoseKo or the console.
-         *
-         * If a module feels responsible for this command, it returns true, and the processing will terminated.
          *
          * If a command is entered that requires an output, the module itself is responsible for handling it.
          * It must then determine based on the arguments whether to display the output on the console or send a message via diagnoseKo.
+         * 
+         * @param configured indicates whether the device is configured by ETS
+         * @param cmd the command string
+         * @param diagnoseKo true if called via diagnoseKo, false if called via console
+         * @return returns true if the module feels responsible for this command, to indicate the processing has to be terminated.
+         */
+        virtual bool processCommand(bool configured, const std::string cmd, bool diagnoseKo);
+
+        /**
+         * This method is called when a command is entered in the console or the diagnoseKo.
+         *
+         * If a command is entered that requires an output, the module itself is responsible for handling it.
+         * It must then determine based on the arguments whether to display the output on the console or send a message via diagnoseKo.
+         *
+         * Will be called for knx.configured()==true by processCommand(bool configured, ...)
+         * Should be overwritten in module implementation, when dependant on configured state.
+         *
+         * @param cmd the command string
+         * @param diagnoseKo true if called via diagnoseKo, false if called via console
          */
         virtual bool processCommand(const std::string cmd, bool diagnoseKo);
 


### PR DESCRIPTION
Basierend auf Diskussion. Verhalten analog `Base::setup` und `Base::loop`

Ändert das aktuelle Verhalten (und sorgt für Anpassungsbedarf an Modulen), daher Abwägung/Diskussion erforderlich.