### PR TITLE
Write GPIO Preset Value After Setting PIN Mode to Avoid it Getting Ignored

### DIFF
--- a/src/OpenKNX/GPIO/DriverEmbedded.cpp
+++ b/src/OpenKNX/GPIO/DriverEmbedded.cpp
@@ -32,9 +32,9 @@ namespace OpenKNX
 
         void DriverEmbedded::GPIOpinMode(uint8_t pin, int mode, bool preset, int status)
         {
+            pinMode(pin, mode);
             if(preset)
                 digitalWriteFast(pin, status);
-            pinMode(pin, mode);
         }
 
         void DriverEmbedded::GPIOdigitalWrite(uint8_t pin, int status)


### PR DESCRIPTION
Hello @Ing-Dom,

I noticed that a PIN mode output preset of `HIGH` was ignored (which my bi-stable relays did not appreciate ;-) ).

It looks like that the actual `pinMode` call always reverts the PIN state to its default which is `LOW` for outputs.

Changing the order to first set the PIN mode and directly afterwards the preset state (if any) fixes the issue for me.

Best regards
Andreas