### PR TITLE
Save GPIO Expander Init Results and Log Them at the End of Initialization Phase

### DIFF
--- a/src/OpenKNX/Common.cpp
+++ b/src/OpenKNX/Common.cpp
@@ -298,7 +298,10 @@ namespace OpenKNX
 #endif
 
         if (!knx.configured()) // fallback if unconfigured
+        {
+            openknx.gpio.showInitResults();
             openknx.console.showInformations();
+        }
     }
 
 #ifdef OPENKNX_DUALCORE
@@ -559,6 +562,7 @@ namespace OpenKNX
 #endif
 
         logDebugP("processAfterStartupDelay");
+        openknx.gpio.showInitResults();
         openknx.console.showInformations();
         openknx.logger.log("Type \"help\" to view a list of available commands.");
         logIndentUp();

--- a/src/OpenKNX/GPIO/Manager.cpp
+++ b/src/OpenKNX/GPIO/Manager.cpp
@@ -19,6 +19,7 @@ namespace OpenKNX
         const OPENKNX_GPIO_T GPIO_TYPES[1] = {OPENKNX_GPIO_T_EMBEDDED};
         #endif
         Base* GPIOExpanders[OPENKNX_GPIO_NUM+1];
+        int GPIOInitResults[OPENKNX_GPIO_NUM+1]; // 0 = OK, INT_MIN = type not found, else error code from init()
 
         Manager::Manager()
         {
@@ -50,63 +51,49 @@ namespace OpenKNX
                     case OPENKNX_GPIO_T_TCA9555:
                     {
                         GPIOExpanders[i] = new DriverTCA9555(GPIO_ADDRS[i], &OPENKNX_GPIO_WIRE);
-                        int statuscode = GPIOExpanders[i]->init();
-                        if(statuscode)
-                        {
-                            logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], statuscode);
-                        }
-                        else
-                        {
-                            logInfoP("connected to GPIO Expander %u with address %u", i, GPIO_ADDRS[i]);
-                        }
+                        GPIOInitResults[i] = GPIOExpanders[i]->init();
                     }
                     break;
                     case OPENKNX_GPIO_T_TCA6408:
                     {
                         GPIOExpanders[i] = new DriverTCA6408(GPIO_ADDRS[i], &OPENKNX_GPIO_WIRE, GPIO_INTS[i]);
-                        int statuscode = GPIOExpanders[i]->init();
-                        if(statuscode)
-                        {
-                            logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], statuscode);
-                        }
-                        else
-                        {
-                            logInfoP("connected to GPIO Expander %u with address %u", i, GPIO_ADDRS[i]);
-                        }
+                        GPIOInitResults[i] = GPIOExpanders[i]->init();
                     }
                     break;
                     case OPENKNX_GPIO_T_PCA9557:
                     {
                         GPIOExpanders[i] = new DriverPCA9557(GPIO_ADDRS[i], &OPENKNX_GPIO_WIRE);
-                        int statuscode = GPIOExpanders[i]->init();
-                        if(statuscode)
-                        {
-                            logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], statuscode);
-                        }
-                        else
-                        {
-                            logInfoP("connected to GPIO Expander %u with address %u", i, GPIO_ADDRS[i]);
-                        }
+                        GPIOInitResults[i] = GPIOExpanders[i]->init();
                     }
                     break;
                     case OPENKNX_GPIO_T_PCA9554:
                     {
                         GPIOExpanders[i] = new DriverPCA9554(GPIO_ADDRS[i], &OPENKNX_GPIO_WIRE);
-                        int statuscode = GPIOExpanders[i]->init();
-                        if(statuscode)
-                        {
-                            logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], statuscode);
-                        }
-                        else
-                        {
-                            logInfoP("connected to GPIO Expander %u with address %u", i, GPIO_ADDRS[i]);
-                        }
+                        GPIOInitResults[i] = GPIOExpanders[i]->init();
                     }
                     break;
                     #endif
                     default:
-                        ;
-                        logErrorP("GPIO_TYPE %u not found", GPIO_TYPES[i]);
+                        GPIOInitResults[i] = INT_MAX;
+                }
+            }
+        }
+
+        void Manager::showInitResults()
+        {
+            for(int i = 1; i < OPENKNX_GPIO_NUM+1; i++)
+            {
+                if (GPIOInitResults[i] == 0)
+                {
+                    logInfoP("connected to GPIO Expander %u with address %u", i, GPIO_ADDRS[i]);
+                }
+                else if (GPIOInitResults[i] == INT_MIN)
+                {
+                    logErrorP("GPIO_TYPE %u not found", GPIO_TYPES[i]);
+                }
+                else
+                {
+                    logErrorP("no connection to GPIO Expander %u with address %u (Errorcode: %u)", i, GPIO_ADDRS[i], GPIOInitResults[i]);
                 }
             }
         }

--- a/src/OpenKNX/GPIO/Manager.h
+++ b/src/OpenKNX/GPIO/Manager.h
@@ -22,6 +22,7 @@ namespace OpenKNX
             ~Manager();
 
             void init();
+            void showInitResults();
             void loop();
 
             std::string logPrefix();


### PR DESCRIPTION
Hello @Ing-Dom,

as I had the issue yesterday again that I was searching why something is not working, just to find out a GPIO expander was not found (without any log output), I made a change to the GPIO manager now - as discussed before - to save the initialization results of the exanders and instead of logging this immediately (when serial console is not available yet), only logging it at the end of the initialization phase (right before the OpenKNX "Information").

It might be even nicer to include the expander information in the main OpenKNX "Information" console output itself eventually, but for now I just wanted to have a working solution that we at least get this really important console output about expanders again "somewhere".

Best regards
Andreas