### PR TITLE
Call "processBeforeRestart()" Also When Using Restart Command

### DIFF
--- a/src/OpenKNX/Console.cpp
+++ b/src/OpenKNX/Console.cpp
@@ -109,6 +109,7 @@ namespace OpenKNX
         }
         else if (!diagnoseKo && (cmd == "r" || cmd == "restart"))
         {
+            openknx.common.processBeforeRestart();
             delay(20);
             openknx.restart();
         }


### PR DESCRIPTION
Let's please also call `processBeforeRestart()` when the restart command `r` is used if there is not a very specific reason why this was not done so far.

Concrete use case for me is the bus power supply where I need to do quite a lot of restart tests and while doing so need to make sure my module `processBeforeRestart()` method gets actually called.