### PR TITLE
Restore Script to Only Create Links

### DIFF
--- a/scripts/restore/Restore-Dependencies-LinksOnly.ps1
+++ b/scripts/restore/Restore-Dependencies-LinksOnly.ps1
@@ -1,0 +1,42 @@
+<#
+Open ■
+┬────┴  Restore-Dependencies
+■ KNX   2024 OpenKNX - Erkan Çolak
+
+FILEPATH: restore/Restore-Dependencies-Branch.ps1
+#>
+
+param(
+  # Set the Git checkout mode
+  [ValidateSet("None", "Branch", "Hash")]
+  [string]$GitCheckoutMode = "None", # Default is Branch
+
+  # Force the script to recreate symbolic links
+  [switch]$ForceRecreateSymLinks = $true, # Default is $true
+  
+  # "dependencies.txt" file
+  [string]$DependenciesFile = "dependencies.txt", # Default is "dependencies.txt"
+
+  # Check for privileges (Windows only)
+  [switch]$CheckForDeveloperMode = $false,  # Default is $false
+  [switch]$CheckForSymbolicLinkPermissions = $true, # Default is $true
+  [switch]$CheckForAdminOnly = $false, # Default is $false
+
+  # Set the Write-Host message behavior
+  [switch]$Verbose = $false, # Default is $false
+  [switch]$DebugMsg = $false  # Default is $false
+)
+
+# Construct the command to invoke Restore-Dependencies.ps1
+$command = ".\Restore-Dependencies.ps1" +
+           " -GitCheckoutMode $GitCheckoutMode" +
+           " -ForceRecreateSymLinks:`$$ForceRecreateSymLinks" +
+           " -DependenciesFile $DependenciesFile" +
+           " -CheckForDeveloperMode:`$$CheckForDeveloperMode" +
+           " -CheckForSymbolicLinkPermissions:`$$CheckForSymbolicLinkPermissions" +
+           " -CheckForAdminOnly:`$$CheckForAdminOnly" +
+           " -Verbose:`$$Verbose" +
+           " -DebugMsg:`$$DebugMsg"
+
+# Execute the command
+Invoke-Expression $command

--- a/scripts/restore/Restore-Dependencies.ps1
+++ b/scripts/restore/Restore-Dependencies.ps1
@@ -39,8 +39,8 @@ Here's a high-level description of what it does:
 # Optional Input Parameters
 param(
   # Set the Git checkout mode
-  [ValidateSet("Branch", "Hash")]
-  [string]$GitCheckoutMode= "Hash", # Branch or Hash. Default is Hash
+  [ValidateSet("None", "Branch", "Hash")]
+  [string]$GitCheckoutMode= "Hash", # None, Branch or Hash. Default is Hash
 
   # Force the script to recreate symbolic links
   [switch]$ForceRecreateSymLinks= $true, # Default is $true
@@ -690,12 +690,13 @@ $projectFilesGitInfo = CreateGitDependencyInfo $projectDir $dependedProjects
 if($DebugMsg) { $projectFilesGitInfo | ForEach-Object { Write-Output $_ } }
  # Output each project file's git information
 
-# Call the CloneRepository function with the project files' git information and the depended projects
-Write-Host -ForegroundColor Yellow "- Checking, cloning and rebranching the git repositories for each dependency."
-$CloneDir = (Resolve-Path (Join-Path $projectDir '..')).Path
-if($Verbose) { Write-Host $CloneDir }
-CloneRepository $projectFilesGitInfo $dependedProjects $CloneDir ($GitCheckoutMode -eq "Hash")
-
+if ($GitCheckoutMode -ne "None") {
+  # Call the CloneRepository function with the project files' git information and the depended projects
+  Write-Host -ForegroundColor Yellow "- Checking, cloning and rebranching the git repositories for each dependency."
+  $CloneDir = (Resolve-Path (Join-Path $projectDir '..')).Path
+  if($Verbose) { Write-Host $CloneDir }
+  CloneRepository $projectFilesGitInfo $dependedProjects $CloneDir ($GitCheckoutMode -eq "Hash")
+}
 
 if($Verbose) { Write-Host -ForegroundColor Yellow "- Checking and creating symbolic links for each project file." }
 CreateSymbolicLink $projectDir $projectFilesGitInfo


### PR DESCRIPTION
I often wanted to just restore the links to my existent GIT repos without touching the repos itself (no branch change, nothing).

Therefore, I have added an additional PowerShell script that allows this.