### PR TITLE
Fix Typo: "Noitz" -> "Notiz"

### DIFF
--- a/src/InfoLed.part.xml
+++ b/src/InfoLed.part.xml
@@ -82,7 +82,7 @@
                                                     </Columns>
                                                     <ParameterSeparator Id="%AID%_PS-nnn" Text="LED" Cell="1,2" UIHint="Headline" />
                                                     <ParameterSeparator Id="%AID%_PS-nnn" Text="Funktion" Cell="1,3" UIHint="Headline" />
-                                                    <ParameterSeparator Id="%AID%_PS-nnn" Text="Noitz" Cell="1,4" UIHint="Headline" />
+                                                    <ParameterSeparator Id="%AID%_PS-nnn" Text="Notiz" Cell="1,4" UIHint="Headline" />
                                                 </ParameterBlock>
 
                                                 <ParameterBlock Id="%AID%_PB-nnn" Inline="true" Layout="Grid" HelpContext="BASE-Info-LEDs">


### PR DESCRIPTION
Zur Integration beim nächsten Update der ETS-App-Version.

**NICHT** für v1.6.1