### PR TITLE
add the mode "HashReset" to the Restore-Dpendencies powershell.

### DIFF
--- a/scripts/restore/Restore-Dependencies-HashReset.ps1
+++ b/scripts/restore/Restore-Dependencies-HashReset.ps1
@@ -1,0 +1,42 @@
+<#
+Open ■
+┬────┴  Restore-Dependencies
+■ KNX   2026 OpenKNX - Ing-Dom
+
+FILEPATH: restore/Restore-Dependencies-HashReset.ps1
+#>
+
+param(
+  # Set the Git checkout mode
+  [ValidateSet("None", "Branch", "Hash", "HashReset")]
+  [string]$GitCheckoutMode= "HashReset", # None, Branch, Hash or HashReset. Default is HashReset
+
+  # Force the script to recreate symbolic links
+  [switch]$ForceRecreateSymLinks = $true, # Default is $true
+  
+  # "dependencies.txt" file
+  [string]$DependenciesFile = "dependencies.txt", # Default is "dependencies.txt"
+
+  # Check for privileges (Windows only)
+  [switch]$CheckForDeveloperMode = $false,  # Default is $false
+  [switch]$CheckForSymbolicLinkPermissions = $true, # Default is $true
+  [switch]$CheckForAdminOnly = $false, # Default is $false
+
+  # Set the Write-Host message behavior
+  [switch]$Verbose = $false, # Default is $false
+  [switch]$DebugMsg = $false  # Default is $false
+)
+
+# Construct the command to invoke Restore-Dependencies.ps1
+$command = ".\Restore-Dependencies.ps1" +
+           " -GitCheckoutMode $GitCheckoutMode" +
+           " -ForceRecreateSymLinks:`$$ForceRecreateSymLinks" +
+           " -DependenciesFile $DependenciesFile" +
+           " -CheckForDeveloperMode:`$$CheckForDeveloperMode" +
+           " -CheckForSymbolicLinkPermissions:`$$CheckForSymbolicLinkPermissions" +
+           " -CheckForAdminOnly:`$$CheckForAdminOnly" +
+           " -Verbose:`$$Verbose" +
+           " -DebugMsg:`$$DebugMsg"
+
+# Execute the command
+Invoke-Expression $command

--- a/scripts/restore/Restore-Dependencies.ps1
+++ b/scripts/restore/Restore-Dependencies.ps1
@@ -39,8 +39,8 @@ Here's a high-level description of what it does:
 # Optional Input Parameters
 param(
   # Set the Git checkout mode
-  [ValidateSet("None", "Branch", "Hash")]
-  [string]$GitCheckoutMode= "Hash", # None, Branch or Hash. Default is Hash
+  [ValidateSet("None", "Branch", "Hash", "HashReset")]
+  [string]$GitCheckoutMode= "Hash", # None, Branch, Hash or HashReset. Default is Hash
 
   # Force the script to recreate symbolic links
   [switch]$ForceRecreateSymLinks= $true, # Default is $true
@@ -402,8 +402,8 @@ function CloneRepository($projectFilesGitInfo, $dependedProjects, $CloneDir, $Cl
 
         if($CloneModeHash) {
           $CheckOutTarget = $($dependedProject.Hash)  # Optional: If the CloneModeHash is true, use the Hash
-        } else {
-          $CheckOutTarget = $($dependedProject.Branch) # If the CloneModeHash is false (default), use the Branch
+        } else { 
+          $CheckOutTarget = $($dependedProject.Branch) # If the CloneModeHash is not Hash (Branch or HashReset) use the Branch
         }
 
         # For git-version >=2.23, use the 'switch' command for branch-restore
@@ -425,8 +425,16 @@ function CloneRepository($projectFilesGitInfo, $dependedProjects, $CloneDir, $Cl
           throw "Git checkout failed with exit code $LASTEXITCODE"
         }
 
+        if($GitCheckoutMode -eq "HashReset") {
+            if($Verbose) { 
+              Invoke-Expression "$GitCmd reset --hard $($dependedProject.Hash)"
+            } else { 
+              Invoke-Expression "$GitCmd reset --hard $($dependedProject.Hash) -q" | Out-Null
+            }
+        }
+
         if($true) { 
-          $checkoutTarget = if ($CloneModeHash) {  "Hash '$($dependedProject.Hash)'" } else { "Branch '$($dependedProject.Branch)'" }
+          $checkoutTarget = if ($CloneModeHash) {  "Hash '$($dependedProject.Hash)'" } else { if($GitCheckoutMode -eq "HashReset") { "Branch '$($dependedProject.Branch)' with Hash '$($dependedProject.Hash)'" } else {"Branch '$($dependedProject.Branch)'"} }
           Write-Host "- CloneRepository - '$($dependedProject.ProjectName)' $($checkoutTarget) Checked out."([Char]0x221A) -ForegroundColor Green 
         }
       }


### PR DESCRIPTION
This mode checks out the branch and then resets the branch to the desired hash. This does NOT lead to a detached head as the "Hash" mode, so it is possible to create a release. The status of the local git repo is identical as if a potential new commit on this branch was never pulled. It can reset locally committed changes on this branch, so be careful. "Reset" in the name of this mode should rise awareness.