### PR TITLE
Move `MAIN_version` into Separate File to Allow Version Control of `include/versions.h`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ or more OFMs (OpenKNX Function Modules).
 
 > **Not self-contained:** OGM-Common cannot be compiled on its own. It
 > needs a concrete device project that provides `hardware.h`, `knxprod.h`,
-> `versions.h`, and a `main.cpp` with the device-specific setup. OFMs
+> `versions.h`, `version_main.h`, and a `main.cpp` with the device-specific setup. OFMs
 > (e.g. OFM-Network under `../OFM-Network`) build on top of OGM-Common —
 > not the other way around.
 
@@ -239,7 +239,7 @@ Runs as a PlatformIO pre-script on **every** OAM build (device project),
 not per module — must be wired into the device project's `platformio.ini`
 as `extra_scripts`. Generates `include/versions.h` (module/build versions)
 among other things, and cleans up stale
-`lib/OGM-Common/include/{knxprod,versions,hardware}.h` (leftovers from an
+`lib/OGM-Common/include/{knxprod,versions,version_main,hardware}.h` (leftovers from an
 earlier convention).
 
 ### Web Assets (`include/webassets.h`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## upcoming releases
 
 * Fix (ESP32): GPIO expanders did not build on ESP32 — `GPIO::Manager::init()` called `setSDA()`/`setSCL()`, which only exist in arduino-pico. On ESP32 the pins are now passed to `OPENKNX_GPIO_WIRE.begin(sda, scl)` instead; the `OPENKNX_GPIO_SDA`/`OPENKNX_GPIO_SCL` defines are unchanged
+* Fix: Move MAIN_version from `include/versions.h` into own generated `include/version_main.h`, as this version can never be included in git release commit
 
 ## 1.9.1: 2026-08-14
 

--- a/scripts/pio/prepare.py
+++ b/scripts/pio/prepare.py
@@ -113,13 +113,26 @@ def get_ets_version(version_string):
 get_all_library_dependencies(project)
 
 print()
+base_dir = pathlib.Path().resolve()
+
+print("{}Generate include/version_main.h{}".format(console_color.YELLOW, console_color.END))
+with open("include/version_main.h", "w") as version_file:
+    version_file.write("//\n")
+    version_file.write("// IMPORTANT: Do NOT include this file in git, as this will NOT match the resulting commit-hash!\n")
+    version_file.write("// => you should add include/version_main.h to .gitignore\n")
+    version_file.write("//\n\n")
+    version_file.write("#pragma once\n\n")
+    version_main = get_git_version(base_dir)
+    version_file.write("#define MAIN_Version \"{}\"\n".format(version_main))
+    print("{}  {}: {} ({}){}".format(console_color.CYAN, "MAIN_Version", version_main, "this OAM", console_color.END))
+print()
+
 print("{}Generate include/versions.h{}".format(console_color.YELLOW, console_color.END))
 
 openknx_modules = {k: v for k, v in library_versions.items() if k.startswith("OGM") or k.startswith("OFM")}
 # openknx_modules["nodir"] = None # to test missing directory
 
 # get git versions
-base_dir = pathlib.Path().resolve()
 for name, lib_version in openknx_modules.items():
   try:
     git_version = get_git_version(base_dir / basepath / name)
@@ -134,7 +147,6 @@ for name, lib_version in openknx_modules.items():
 # build defines
 with open("include/versions.h", "w") as version_file:
     version_file.write("#pragma once\n\n")
-    version_file.write("#define MAIN_Version \"{}\"\n".format(get_git_version(base_dir)))
     version_file.write("#define KNX_Version \"{}\"\n".format(library_versions["knx"] + "+" + get_git_version(base_dir / basepath / "knx")))
     # additional_defines = dict()
     for name, version in openknx_modules.items():

--- a/src/OpenKNX/Information.h
+++ b/src/OpenKNX/Information.h
@@ -3,6 +3,7 @@
 #include "knxprod.h"
 #include <knx.h>
 #include <string>
+#include <version_main.h>
 
 namespace OpenKNX
 {


### PR DESCRIPTION
# Hintergrund

`include/versions.h` enthielt mit diesem define bislang den commit-hash des repos selbst, wenn man diese Datei mit eincheckt. Mit jedem Build würde somit automatisch ein diff entstehen.

# Alternative

Zur Diskussion: Auch versions.h grundsätzlich ausschließen. (Das ist bei diversen Repos aktuell nicht der Fall)
